### PR TITLE
Carey cie

### DIFF
--- a/R/plot-ats.R
+++ b/R/plot-ats.R
@@ -66,7 +66,7 @@
 #'            geom_pointrange guides
 #'
 plot_ats <- function(M, xlab = "Year", ylab = "Acoustic trawl survey biomass",
-                     xlim = NULL, ylim = NULL, alpha = 0.1, biomass = TRUE, color = "red") {
+                     xlim = NULL, ylim = NULL, alpha = 0.1, biomass = TRUE, color = "red",error_bars = TRUE) {
     xlab <- paste0("\n", xlab)
     ylab <- paste0(ylab, "\n")
 
@@ -84,12 +84,16 @@ plot_ats <- function(M, xlab = "Year", ylab = "Acoustic trawl survey biomass",
     }
     if (length(M) == 1)
     {
-        p <- p + geom_line(aes(x = year, y = pre)) +geom_point(aes(x=year, y=obs),size=2,color=color) +
-            geom_errorbar(aes(x = year, ymax = ub, ymin = lb),width=.5)
+        p <- p + geom_line(aes(x = year, y = pre)) +geom_point(aes(x=year, y=obs),size=2,color=color)
+        if (error_bars == TRUE) {
+         p<-p + geom_errorbar(aes(x = year, ymax = ub, ymin = lb),width=.5)
+        }
     } else {
         dw <- 0.5
-        p <- p + geom_line(aes(x = year, y = pre, col = Model), width=1, position=position_dodge(width=dw)) + geom_point(aes(x=year, y=obs,col=Model,fill=Model),position = position_dodge(width=dw)) +
-           geom_pointrange(aes(year, obs, ymax = ub, ymin = lb, color = Model,fill=Model), shape = 1, linetype = "solid", position = position_dodge(width = dw))
+        p <- p + geom_line(aes(x = year, y = pre, col = Model), width=1, position=position_dodge(width=dw)) + geom_point(aes(x=year, y=obs,col=Model,fill=Model),position = position_dodge(width=dw))
+        if (error_bars == TRUE) {
+          p<- p + geom_pointrange(aes(year, obs, ymax = ub, ymin = lb, color = Model,fill=Model), shape = 1, linetype = "solid", position = position_dodge(width = dw))
+        }
             #geom_errorbar(aes(x = year, ymax = ub, ymin = lb),width=0.5,position=position_dodge(width=0.9))
     }
 

--- a/R/plot-avo.R
+++ b/R/plot-avo.R
@@ -42,7 +42,7 @@
 #' @export
 #'
 #' @return A ggplot object with the plotted data.
-plot_avo <- function(M, xlab = "Year", ylab = "Acoustic return (Sa from AVO) ", ylim = NULL)
+plot_avo <- function(M, xlab = "Year", ylab = "Acoustic return (Sa from AVO) ", ylim = NULL,error_bars = TRUE)
 {
   xlab <- paste0("\n", xlab)
   ylab <- paste0(ylab, "\n")
@@ -57,14 +57,18 @@ plot_avo <- function(M, xlab = "Year", ylab = "Acoustic return (Sa from AVO) ", 
 
   if (length(M) == 1) {
     p <- p + geom_line(aes(x = year, y = pre)) +
-						geom_point(aes(x=year, y=obs)) + 
-      geom_errorbar(aes(x = year, ymax = ub, ymin = lb),width=0.5)
+						geom_point(aes(x=year, y=obs))
+      if (error_bars == TRUE) {
+        p<-p + geom_errorbar(aes(x = year, ymax = ub, ymin = lb),width=0.5)
+      }
     } else {
     dw <- 0.5
     p <- p + geom_line(aes(x = year, y = pre, colour = Model), width=1) + geom_point(aes(x=year, y=obs),size=2) + 
-      geom_point(aes(x = year, y = obs, col = Model, fill = Model), position = position_dodge(width = dw)) +
-      geom_pointrange(aes(year, obs, ymax = ub, ymin = lb, color = Model, fill = Model), shape = 1, linetype = "solid", position = position_dodge(width = dw))
+      geom_point(aes(x = year, y = obs, col = Model, fill = Model), position = position_dodge(width = dw))
+      if (error_bars == TRUE) {
+      p<-p + geom_pointrange(aes(year, obs, ymax = ub, ymin = lb, color = Model, fill = Model), shape = 1, linetype = "solid", position = position_dodge(width = dw))
             #geom_errorbar(aes(x = year, ymax = ub, ymin = lb),width=0.5)
+      }
     }
     p <- p +scale_x_continuous(limits=c(2005,2022),breaks=seq(2006,2023,2)) 
     return(p + .THEME)

--- a/R/plot-bts.R
+++ b/R/plot-bts.R
@@ -54,7 +54,8 @@ plot_bts <- function(M,
                      xlim = NULL,
                      ylim = NULL,
                      color = "purple",
-                     biomass = TRUE) {
+                     biomass = TRUE,
+                     error_bars = TRUE) {
 
   mdf <- .get_bts_df(M, biomass = biomass)
 
@@ -69,13 +70,17 @@ plot_bts <- function(M,
 
   if (length(M) == 1) {
     p <- p + geom_line(aes(x = year, y = pre)) +
-      geom_point(aes(x = year, y = obs), size = 2, color = color) +
-      geom_errorbar(aes(x = year, ymax = ub, ymin = lb), width = 0.5)
+      geom_point(aes(x = year, y = obs), size = 2, color = color)
+    if (error_bars==TRUE) {
+     p<- p + geom_errorbar(aes(x = year, ymax = ub, ymin = lb), width = 0.5)
+    }
   } else {
     dw <- 0.5
     p <- p + geom_line(aes(x = year, y = pre, col = Model), width = 1, position = position_dodge(width = dw)) +
-      geom_point(aes(x = year, y = obs, col = Model, fill = Model), position = position_dodge(width = dw)) +
-      geom_pointrange(aes(year, obs, ymax = ub, ymin = lb, color = Model, fill = Model), shape = 1, linetype = "solid", position = position_dodge(width = dw))
+      geom_point(aes(x = year, y = obs, col = Model, fill = Model), position = position_dodge(width = dw))
+    if (error_bars==TRUE) {
+      p<-p + geom_pointrange(aes(year, obs, ymax = ub, ymin = lb, color = Model, fill = Model), shape = 1, linetype = "solid", position = position_dodge(width = dw))
+    }
   }
 
   if (!.OVERLAY) p <- p + guides(colour = FALSE)


### PR DESCRIPTION
Added the option in plot_bts.R and plot_ats.R to skip the error bars, as in the case of inflating variance to effectively leave out the BTS or ATS index.